### PR TITLE
Add support for streaming chunks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.1.4'
-          - '3.3.0'
+          - '3.1.5'
+          - '3.3.1'
 
     steps:
     - uses: actions/checkout@v4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     groq (0.2.0)
       activesupport (> 5)
+      event_stream_parser (~> 1.0)
       faraday (~> 2.0)
       json
 
@@ -57,6 +58,7 @@ GEM
       dry-inflector (~> 1.0)
       dry-logic (~> 1.4)
       zeitwerk (~> 2.6)
+    event_stream_parser (1.0.0)
     faraday (2.9.0)
       faraday-net_http (>= 2.0, < 3.2)
     faraday-net_http (3.1.0)

--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ class MessageBits
 end
 
 bits = MessageBits.new("🍕")
-@client.chat("Write a long poem about patience", stream: bits)
+@client.chat("Write a long poem about pizza", stream: bits)
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -352,6 +352,53 @@ If you pass `--debug` to `bin/console` you will have this logger setup for you.
 bin/console --debug
 ```
 
+### Streaming
+
+If your AI assistant responses are being telecast live to a human, then that human might want some progressive responses. The Groq API supports streaming responses.
+
+Pass a block to `chat()` with either one or two arguments.
+
+1. The first argument is the string content chunk of the response.
+2. The optional second argument is the full response object from the API containing extra metadata.
+
+The final block call will be the last chunk of the response:
+
+1. The first argument will be `nil`
+2. The optional second argument, the full response object, contains a summary of the Groq API usage, such as prompt tokens, prompt time, etc.
+
+```ruby
+puts "🍕 "
+messages = [
+  S("You are a pizza sales person."),
+  U("What do you sell?")
+]
+@client.chat(messages) do |content|
+  print content
+end
+puts
+```
+
+Each chunk of the response will be printed to the console as it is received. It will look pretty.
+
+The default `llama3-7b-8192` model is very very fast and you might not see any streaming. Try a slower model like `llama3-70b-8192` or `mixtral-8x7b-32768`.
+
+```ruby
+@client = Groq::Client.new(model_id: "llama3-70b-8192")
+@client.chat("Write a long poem about patience") do |content|
+  print content
+end
+puts
+```
+
+You can pass in a second argument to get the full response JSON object:
+
+```ruby
+@client.chat("Write a long poem about patience") do |content, response|
+  pp content
+  pp response
+end
+```
+
 ## Examples
 
 Here are some example uses of Groq, of the `groq` gem and its syntax.

--- a/README.md
+++ b/README.md
@@ -399,6 +399,12 @@ You can pass in a second argument to get the full response JSON object:
 end
 ```
 
+Alternately, you can pass a `Proc` or any object that responds to `call` via a `stream:` keyword argument:
+
+```ruby
+@client.chat("Write a long poem about patience", stream: ->(content) { print content })
+```
+
 ## Examples
 
 Here are some example uses of Groq, of the `groq` gem and its syntax.

--- a/README.md
+++ b/README.md
@@ -405,6 +405,37 @@ Alternately, you can pass a `Proc` or any object that responds to `call` via a `
 @client.chat("Write a long poem about patience", stream: ->(content) { print content })
 ```
 
+You could use a class with a `call` method with either one or two arguments, like the `Proc` discussion above.
+
+```ruby
+class MessageBits
+  def initialize(emoji)
+    print "#{emoji} "
+    @bits = []
+  end
+
+  def call(content)
+    if content.nil?
+      puts
+    else
+      print(content)
+      @bits << content
+    end
+  end
+
+  def to_s
+    @bits.join("")
+  end
+
+  def to_assistant_message
+    Assistant(to_s)
+  end
+end
+
+bits = MessageBits.new("🍕")
+@client.chat("Write a long poem about patience", stream: bits)
+```
+
 ## Examples
 
 Here are some example uses of Groq, of the `groq` gem and its syntax.

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,6 +20,16 @@ At the prompt, either talk to the AI agent, or some special commands:
 - `exit` to exit the conversation
 - `summary` to get a summary of the conversation so far
 
+### Streaming
+
+There is also an example of streaming the conversation to terminal as it is received from Groq API.
+
+It defaults to the slower `llama3-70b-8192` model so that the streaming is more noticable.
+
+```bash
+bundle exec examples/groq-user-chat-streaming.rb --agent-prompt examples/agent-prompts/pizzeria-sales.yml
+```
+
 ### Pizzeria
 
 Run the pizzeria example with the following command:

--- a/examples/groq-user-chat-streaming.rb
+++ b/examples/groq-user-chat-streaming.rb
@@ -91,6 +91,26 @@ if can_go_first
   messages << A(message_bits.join(""))
 end
 
+class MessageBits
+  def initialize(emoji)
+    print "#{emoji} "
+    @bits = []
+  end
+
+  def call(content)
+    if content.nil?
+      puts
+    else
+      print(content)
+      @bits << content
+    end
+  end
+
+  def to_assistant_message
+    Assistant(@bits.join(""))
+  end
+end
+
 loop do
   print "#{user_emoji} "
   user_input = gets.chomp
@@ -105,17 +125,8 @@ loop do
 
   messages << U(user_input)
 
-  print "#{agent_emoji} "
-
   # Use Groq to generate a response
-  message_bits = []
-  response = @client.chat(messages) do |content|
-    if content
-      print(content)
-      message_bits << content
-    else
-      puts
-    end
-  end
-  messages << A(message_bits.join(""))
+  message_bits = MessageBits.new(agent_emoji)
+  @client.chat(messages, stream: message_bits)
+  messages << message_bits.to_assistant_message
 end

--- a/examples/groq-user-chat-streaming.rb
+++ b/examples/groq-user-chat-streaming.rb
@@ -7,8 +7,7 @@ require "yaml"
 include Groq::Helpers
 
 @options = {
-  model: "llama3-8b-8192",
-  # model: "llama3-70b-8192",
+  model: "llama3-70b-8192",
   agent_prompt_path: File.join(File.dirname(__FILE__), "agent-prompts/helloworld.yml"),
   timeout: 20
 }

--- a/examples/groq-user-chat-streaming.rb
+++ b/examples/groq-user-chat-streaming.rb
@@ -1,0 +1,122 @@
+#!/usr/bin/env ruby
+
+require "optparse"
+require "groq"
+require "yaml"
+
+include Groq::Helpers
+
+@options = {
+  model: "llama3-8b-8192",
+  # model: "llama3-70b-8192",
+  agent_prompt_path: File.join(File.dirname(__FILE__), "agent-prompts/helloworld.yml"),
+  timeout: 20
+}
+OptionParser.new do |opts|
+  opts.banner = "Usage: ruby script.rb [options]"
+
+  opts.on("-m", "--model MODEL", "Model name") do |v|
+    @options[:model] = v
+  end
+
+  opts.on("-a", "--agent-prompt PATH", "Path to agent prompt file") do |v|
+    @options[:agent_prompt_path] = v
+  end
+
+  opts.on("-t", "--timeout TIMEOUT", "Timeout in seconds") do |v|
+    @options[:timeout] = v.to_i
+  end
+
+  opts.on("-d", "--debug", "Enable debug mode") do |v|
+    @options[:debug] = v
+  end
+end.parse!
+
+raise "Missing --model option" if @options[:model].nil?
+raise "Missing --agent-prompt option" if @options[:agent_prompt_path].nil?
+
+def debug?
+  @options[:debug]
+end
+
+# Read the agent prompt from the file
+agent_prompt = YAML.load_file(@options[:agent_prompt_path])
+user_emoji = agent_prompt["user_emoji"]
+agent_emoji = agent_prompt["agent_emoji"]
+system_prompt = agent_prompt["system_prompt"] || agent_prompt["system"]
+can_go_first = agent_prompt["can_go_first"]
+
+# Initialize the Groq client
+@client = Groq::Client.new(model_id: @options[:model], request_timeout: @options[:timeout]) do |f|
+  if debug?
+    require "logger"
+
+    # Create a logger instance
+    logger = Logger.new($stdout)
+    logger.level = Logger::DEBUG
+
+    f.response :logger, logger, bodies: true  # Log request and response bodies
+  end
+end
+
+puts "Welcome to the AI assistant! I'll respond to your queries."
+puts "You can quit by typing 'exit'."
+
+def produce_summary(messages)
+  combined = messages.map do |message|
+    if message["role"] == "user"
+      "User: #{message["content"]}"
+    else
+      "Assistant: #{message["content"]}"
+    end
+  end.join("\n")
+  response = @client.chat([
+    S("You are excellent at reading a discourse between a human and an AI assistant and summarising the current conversation."),
+    U("Here is the current conversation:\n\n------\n\n#{combined}")
+  ])
+  puts response["content"]
+end
+
+messages = [S(system_prompt)]
+
+if can_go_first
+  print "#{agent_emoji} "
+  message_bits = []
+  response = @client.chat(messages) do |content|
+    # content == nil on last message; and "" on first message
+    next unless content
+    print(content)
+    message_bits << content
+  end
+  puts
+  messages << A(message_bits.join(""))
+end
+
+loop do
+  print "#{user_emoji} "
+  user_input = gets.chomp
+
+  break if user_input.downcase == "exit"
+
+  # produce summary
+  if user_input.downcase == "summary"
+    produce_summary(messages)
+    next
+  end
+
+  messages << U(user_input)
+
+  print "#{agent_emoji} "
+
+  # Use Groq to generate a response
+  message_bits = []
+  response = @client.chat(messages) do |content|
+    if content
+      print(content)
+      message_bits << content
+    else
+      puts
+    end
+  end
+  messages << A(message_bits.join(""))
+end

--- a/groq.gemspec
+++ b/groq.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday", "~> 2.0"
   spec.add_dependency "json"
   spec.add_dependency "activesupport", "> 5" # for Concerns
+  spec.add_dependency "event_stream_parser", "~> 1.0"
 
   spec.add_development_dependency "vcr", "~> 6.0"
   spec.add_development_dependency "webmock", "~> 3.0"

--- a/lib/groq/client.rb
+++ b/lib/groq/client.rb
@@ -131,11 +131,22 @@ class Groq::Client
         chunk = JSON.parse(data)
         delta = chunk.dig("choices", 0, "delta")
         content = delta.dig("content")
-        # if user_proc takes one argument, pass the content
-        if user_proc.arity == 1
-          user_proc.call(content)
+        if user_proc.is_a?(Proc)
+          # if user_proc takes one argument, pass the content
+          if user_proc.arity == 1
+            user_proc.call(content)
+          else
+            user_proc.call(content, chunk)
+          end
+        elsif user_proc.respond_to?(:call)
+          # if call method takes one argument, pass the content
+          if user_proc.method(:call).arity == 1
+            user_proc.call(content)
+          else
+            user_proc.call(content, chunk)
+          end
         else
-          user_proc.call(content, chunk)
+          raise ArgumentError, "The stream_chunk parameter must be a Proc or have a #call method"
         end
       end
     end

--- a/lib/groq/client.rb
+++ b/lib/groq/client.rb
@@ -22,7 +22,7 @@ class Groq::Client
     @faraday_middleware = faraday_middleware
   end
 
-  def chat(messages, model_id: nil, tools: nil, tool_choice: nil, max_tokens: nil, temperature: nil, json: false, &stream_chunk)
+  def chat(messages, model_id: nil, tools: nil, tool_choice: nil, max_tokens: nil, temperature: nil, json: false, stream: nil, &stream_chunk)
     unless messages.is_a?(Array) || messages.is_a?(String)
       raise ArgumentError, "require messages to be an Array or String"
     end
@@ -33,7 +33,7 @@ class Groq::Client
 
     model_id ||= @model_id
 
-    if stream_chunk
+    if stream_chunk ||= stream
       require "event_stream_parser"
     end
 

--- a/test/fixtures/vcr_cassettes/llama3-8b-8192/chat_streaming_chunks.yml
+++ b/test/fixtures/vcr_cassettes/llama3-8b-8192/chat_streaming_chunks.yml
@@ -1,0 +1,93 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.groq.com/openai/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"llama3-8b-8192","messages":[{"role":"user","content":"What''s
+        the next day after Wednesday?"}],"max_tokens":1024,"temperature":1,"stream":true}'
+    headers:
+      Authorization:
+      - Bearer <GROQ_API_KEY>
+      User-Agent:
+      - groq-ruby/0.2.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 25 Apr 2024 01:59:11 GMT
+      Content-Type:
+      - text/event-stream
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache
+      Vary:
+      - Origin
+      X-Ratelimit-Limit-Requests:
+      - '14400'
+      X-Ratelimit-Limit-Tokens:
+      - '12000'
+      X-Ratelimit-Remaining-Requests:
+      - '14399'
+      X-Ratelimit-Remaining-Tokens:
+      - '11986'
+      X-Ratelimit-Reset-Requests:
+      - 6s
+      X-Ratelimit-Reset-Tokens:
+      - 70ms
+      X-Request-Id:
+      - req_01hw9fmsene0srtm0eb8jhddm0
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - h3=":443"; ma=86400
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=LfoNMl1Q7T_Ersp1U_iEECdQ132gXScTuGFqsm2GggQ-1714010351-1.0.1.1-TUn5PW6rtOzJMaul4cDurTGYsEhoLPIbJiu28U7FCG1pxNB0bP1GQP1by9Nv940ATJJS332dvOoU.dbyx_Spqw;
+        path=/; expires=Thu, 25-Apr-24 02:29:11 GMT; domain=.groq.com; HttpOnly; Secure;
+        SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 879abb759bd6aaf3-SYD
+    body:
+      encoding: UTF-8
+      string: |+
+        data: {"id":"chatcmpl-bb3daaf2-7f1b-4260-bd4d-1f69a8bf4ec2","object":"chat.completion.chunk","created":1714010351,"model":"llama3-8b-8192","system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"x_groq":{"id":"req_01hw9fmsene0srtm0eb8jhddm0"}}
+
+        data: {"id":"chatcmpl-bb3daaf2-7f1b-4260-bd4d-1f69a8bf4ec2","object":"chat.completion.chunk","created":1714010351,"model":"llama3-8b-8192","system_fingerprint":"fp_af05557ca2","choices":[{"index":0,"delta":{"content":"The"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-bb3daaf2-7f1b-4260-bd4d-1f69a8bf4ec2","object":"chat.completion.chunk","created":1714010351,"model":"llama3-8b-8192","system_fingerprint":"fp_af05557ca2","choices":[{"index":0,"delta":{"content":" next"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-bb3daaf2-7f1b-4260-bd4d-1f69a8bf4ec2","object":"chat.completion.chunk","created":1714010351,"model":"llama3-8b-8192","system_fingerprint":"fp_af05557ca2","choices":[{"index":0,"delta":{"content":" day"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-bb3daaf2-7f1b-4260-bd4d-1f69a8bf4ec2","object":"chat.completion.chunk","created":1714010351,"model":"llama3-8b-8192","system_fingerprint":"fp_af05557ca2","choices":[{"index":0,"delta":{"content":" after"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-bb3daaf2-7f1b-4260-bd4d-1f69a8bf4ec2","object":"chat.completion.chunk","created":1714010351,"model":"llama3-8b-8192","system_fingerprint":"fp_af05557ca2","choices":[{"index":0,"delta":{"content":" Wednesday"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-bb3daaf2-7f1b-4260-bd4d-1f69a8bf4ec2","object":"chat.completion.chunk","created":1714010351,"model":"llama3-8b-8192","system_fingerprint":"fp_af05557ca2","choices":[{"index":0,"delta":{"content":" is"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-bb3daaf2-7f1b-4260-bd4d-1f69a8bf4ec2","object":"chat.completion.chunk","created":1714010351,"model":"llama3-8b-8192","system_fingerprint":"fp_af05557ca2","choices":[{"index":0,"delta":{"content":" Thursday"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-bb3daaf2-7f1b-4260-bd4d-1f69a8bf4ec2","object":"chat.completion.chunk","created":1714010351,"model":"llama3-8b-8192","system_fingerprint":"fp_af05557ca2","choices":[{"index":0,"delta":{"content":"!"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-bb3daaf2-7f1b-4260-bd4d-1f69a8bf4ec2","object":"chat.completion.chunk","created":1714010351,"model":"llama3-8b-8192","system_fingerprint":"fp_af05557ca2","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"x_groq":{"id":"req_01hw9fmsene0srtm0eb8jhddm0","usage":{"queue_time":0.173082861,"prompt_tokens":18,"prompt_time":0.008,"completion_tokens":8,"completion_time":0.008,"total_tokens":26,"total_time":0.016}}}
+
+        data: [DONE]
+
+  recorded_at: Thu, 25 Apr 2024 01:59:11 GMT
+recorded_with: VCR 6.2.0
+...

--- a/test/groq/test_client.rb
+++ b/test/groq/test_client.rb
@@ -57,6 +57,29 @@ class TestGroqClient < Minitest::Test
     end
   end
 
+  def test_streaming_chunks
+    VCR.use_cassette("llama3-8b-8192/chat_streaming_chunks") do
+      client = Groq::Client.new(model_id: "llama3-8b-8192")
+      messages = [
+        {role: "user", content: "What's the next day after Wednesday?"}
+      ]
+      contents = []
+      chunks = []
+      response = client.chat(messages) do |content, chunk|
+        contents << content
+        chunks << chunk
+      end
+      assert_equal response, ""
+      assert_equal contents, ["", "The", " next", " day", " after", " Wednesday", " is", " Thursday", "!", nil]
+      assert_equal chunks[0].dig("choices", 0, "delta"), {
+        "role" => "assistant", "content" => ""
+      }
+      assert_equal chunks[1].dig("choices", 0, "delta"), {
+        "content" => "The"
+      }
+    end
+  end
+
   include Groq::Helpers
   def test_chat_messages_with_U_A_helpers
     VCR.use_cassette("llama3-8b-8192/chat_messages") do

--- a/test/groq/test_client.rb
+++ b/test/groq/test_client.rb
@@ -80,6 +80,32 @@ class TestGroqClient < Minitest::Test
     end
   end
 
+  def test_streaming_chunks_with_stream_keyword_argument
+    VCR.use_cassette("llama3-8b-8192/chat_streaming_chunks") do
+      client = Groq::Client.new(model_id: "llama3-8b-8192")
+      messages = [
+        {role: "user", content: "What's the next day after Wednesday?"}
+      ]
+
+      contents = []
+      proc = proc do |content|
+        contents << content
+      end
+
+      response = client.chat(messages, stream: proc)
+
+      assert_equal response, ""
+      assert_equal contents, ["", "The", " next", " day", " after", " Wednesday", " is", " Thursday", "!", nil]
+    end
+  end
+
+  def test_error_if_stream_not_callable
+    client = Groq::Client.new(stream: "does not have call() method")
+    assert_raises ArgumentError do
+      client.chat("What's the next day after Wednesday?", stream: "not a callable")
+    end
+  end
+
   include Groq::Helpers
   def test_chat_messages_with_U_A_helpers
     VCR.use_cassette("llama3-8b-8192/chat_messages") do

--- a/test/groq/test_client.rb
+++ b/test/groq/test_client.rb
@@ -60,9 +60,7 @@ class TestGroqClient < Minitest::Test
   def test_streaming_chunks
     VCR.use_cassette("llama3-8b-8192/chat_streaming_chunks") do
       client = Groq::Client.new(model_id: "llama3-8b-8192")
-      messages = [
-        {role: "user", content: "What's the next day after Wednesday?"}
-      ]
+      messages = [{role: "user", content: "What's the next day after Wednesday?"}]
       contents = []
       chunks = []
       response = client.chat(messages) do |content, chunk|
@@ -83,9 +81,7 @@ class TestGroqClient < Minitest::Test
   def test_streaming_chunks_with_stream_keyword_argument
     VCR.use_cassette("llama3-8b-8192/chat_streaming_chunks") do
       client = Groq::Client.new(model_id: "llama3-8b-8192")
-      messages = [
-        {role: "user", content: "What's the next day after Wednesday?"}
-      ]
+      messages = [{role: "user", content: "What's the next day after Wednesday?"}]
 
       contents = []
       proc = proc do |content|
@@ -96,6 +92,30 @@ class TestGroqClient < Minitest::Test
 
       assert_equal response, ""
       assert_equal contents, ["", "The", " next", " day", " after", " Wednesday", " is", " Thursday", "!", nil]
+    end
+  end
+
+  def test_streaming_chunks_with_callable_object
+    bits_class = Class.new do
+      def initialize
+        @bits = []
+      end
+
+      def call(content)
+        @bits << content
+      end
+
+      def to_s
+        @bits.join("")
+      end
+    end
+    VCR.use_cassette("llama3-8b-8192/chat_streaming_chunks") do
+      client = Groq::Client.new(model_id: "llama3-8b-8192")
+      messages = [{role: "user", content: "What's the next day after Wednesday?"}]
+
+      bits = bits_class.new
+      client.chat(messages, stream: bits)
+      assert_equal bits.to_s, "The next day after Wednesday is Thursday!"
     end
   end
 


### PR DESCRIPTION
Either pass a block to the `chat()` method with one or two arguments:

```ruby
@client = Groq::Client.new(model_id: "llama3-70b-8192")

@client.chat("Write a long poem about patience") do |content|
  print content
end
puts
```

Or pass a `Proc` or callable object to `stream:` keyword argument:

```ruby
class MessageBits
  def initialize(emoji)
    print "#{emoji} "
    @bits = []
  end

  def call(content)
    if content.nil?
      puts
    else
      print(content)
      @bits << content
    end
  end

  def to_s
    @bits.join("")
  end

  def to_assistant_message
    Assistant(to_s)
  end
end

bits = MessageBits.new("🍕")
@client.chat("Write a long poem about pizza", stream: bits)
```


Credit to https://github.com/alexrudall/ruby-openai/blob/main/lib/openai/http.rb for borrowed code